### PR TITLE
Fix broken simbad2k lookup from UI

### DIFF
--- a/src/components/TargetLookup.vue
+++ b/src/components/TargetLookup.vue
@@ -82,8 +82,8 @@ export default {
               this.setLookupStatus(response.error);
             } else {
               this.setLookupStatus('');
-              this.point.x = response.ra.replace(/ /g, ':');
-              this.point.y = response.dec.replace(/ /g, ':');
+              this.point.x = response.ra.toString();
+              this.point.y = response.dec.toString();
               this.onPointUpdate();
             }
           })


### PR DESCRIPTION
Simbad2k ra/dec used to be sexagesimal strings. Now they are decimal numbers returned. The UI expects them as strings, but it shouldn't hurt for them to be decimal strings since it operates on either decimal or sexagesimal formats for those input fields.