### PR TITLE
Feature/use archive thumbs

### DIFF
--- a/src/components/Thumbnail.vue
+++ b/src/components/Thumbnail.vue
@@ -56,6 +56,8 @@ export default {
         .done(function(response) {
           let data = response;
           if (_.isArray(data.thumbnails) && data.thumbnails.length > 0) {
+            // This sorting works to put 'small' before 'large', should also work for 'medium',
+            // but falls back to at least using a thumbnail if one exists for the frame in the archive.
             let thumbnails = _.orderBy(data.thumbnails, ['size'], ['desc']);
             that.thumbnailSmallUrl = thumbnails[0].url || '';
             that.thumbnailLargeUrl = thumbnails[1].url || '';


### PR DESCRIPTION
This switches the thumbnails in the archive to first attempt to load from the archive itself, and then fall back on our thumbnail service if no thumbnails exist for the frame in the archive. It also adds an on-click for thumbnails in the archive to show the large version on click.

[archive-client-thumbnails.webm](https://github.com/user-attachments/assets/3d3bfeb8-ef51-411c-bb2a-0f0f5ea9f06c)
