### PR TITLE
Moved getting profile from main to the App on creation so its failure…

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -45,10 +45,13 @@
         </b-collapse>
       </b-navbar>
     </div>
-    <b-alert v-if="userIsAuthenticatedAndNotMemberOfProposals" variant="info" dismissible>
-      <div>You are not a member of any proposals. Only public data will be shown.</div>
-    </b-alert>
     <b-container class="flex-shrink-0 p-1">
+      <b-alert v-if="userIsAuthenticatedAndNotMemberOfProposals" variant="info" show dismissible>
+        <div>You are not a member of any proposals. Only public data will be shown.</div>
+      </b-alert>
+      <b-alert v-if="profileError" show variant="danger" dismissible @dismissed="profileError = ''">
+        <p>{{ profileError }}</p>
+      </b-alert>
       <router-view class="my-3" />
     </b-container>
     <ArchiveFooter
@@ -70,6 +73,11 @@ export default {
   components: {
     ArchiveFooter
   },
+  data: function() {
+    return {
+      profileError: ''
+    };
+  },
   computed: {
     profile: function() {
       return this.$store.state.profile;
@@ -80,6 +88,17 @@ export default {
     userIsAuthenticatedAndNotMemberOfProposals: function() {
       return this.userIsAuthenticated && this.profile.profile.proposals.length < 1;
     }
+  },
+  created: function () {
+    this.$store
+      .dispatch('getProfileData')
+      .then(() => {
+        this.profileError = '';
+      })
+      .catch((response) => {
+        this.profileError= `Failed to load profile data - ${response.status}: ${response.statusText} - ${response.responseText}`;
+        console.error(this.profileError);
+      });
   },
   methods: {
     logout: function() {

--- a/src/main.js
+++ b/src/main.js
@@ -52,17 +52,9 @@ $.ajax({
   // Initialize archive token if it is available in local storage already
   store.commit('initializeArchiveToken');
 
-  store
-    .dispatch('getProfileData')
-    .then(() => {
-      new Vue({
-        router,
-        store,
-        render: h => h(App)
-      }).$mount('#app');
-    })
-    .catch(() => {
-      // TODO: Display error page
-      console.log('Error getting profile data');
-    });
+  new Vue({
+    router,
+    store,
+    render: h => h(App)
+  }).$mount('#app');
 });


### PR DESCRIPTION
… doesn't block the page loading. Also added an alert to the page with the error if loading the profile fails for any reason. There already is a modal popping up with the error if the request to get frames fails. I tested this by forcing myself into throttle and showing that I can still load the page and login through the page to clear the throttle error.

[archive_handle_throttle.webm](https://github.com/user-attachments/assets/283ab670-785a-433d-bec6-4b9cd66ebcc8)
