### PR TITLE
Set groundwork to fix data inspector issues

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -52,7 +52,7 @@
       <b-alert v-if="profileError" show variant="danger" dismissible @dismissed="profileError = ''">
         <p>{{ profileError }}</p>
       </b-alert>
-      <router-view class="my-3" />
+      <router-view class="my-3" v-if="!loading"/>
     </b-container>
     <ArchiveFooter
       :copyright-organization="this.$store.state.urls.copyrightOrganization"
@@ -75,7 +75,8 @@ export default {
   },
   data: function() {
     return {
-      profileError: ''
+      profileError: '',
+      loading: true
     };
   },
   computed: {
@@ -89,16 +90,16 @@ export default {
       return this.userIsAuthenticated && this.profile.profile.proposals.length < 1;
     }
   },
-  created: function () {
-    this.$store
-      .dispatch('getProfileData')
-      .then(() => {
-        this.profileError = '';
-      })
-      .catch((response) => {
-        this.profileError= `Failed to load profile data - ${response.status}: ${response.statusText} - ${response.responseText}`;
-        console.error(this.profileError);
-      });
+  created: async function () {
+    try {
+      await this.$store.dispatch('getProfileData');
+      this.profileError = '';
+    } catch (response) {
+      this.profileError= `Failed to load profile data - ${response.status}: ${response.statusText} - ${response.responseText}`;
+      console.error(this.profileError);
+    } finally {
+      this.loading = false;
+    }
   },
   methods: {
     logout: function() {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -3,7 +3,6 @@ import VueRouter from 'vue-router';
 import Home from '../views/Home.vue';
 import Login from '../views/Login.vue';
 import NotFound from '../components/NotFound.vue';
-import store from '../store';
 
 Vue.use(VueRouter);
 
@@ -12,21 +11,6 @@ const routes = [
     path: '/',
     name: 'Home',
     component: Home,
-    beforeEnter: (to, from, next) => {
-      // if the route contains a public parameter, honor that
-      if (to.query.public != undefined) {
-        next();
-        return
-      }
-
-      // otherwise send authenticated users to public=false
-      // and unauthenticated users to public=true
-      if (store.state.userIsAuthenticated) {
-          next({ name: 'Home', query: {...to.query, public: "false"}});
-      } else {
-          next({ name: 'Home', query: {...to.query, public: "true"}});
-      }
-    }
   },
   {
     path: '/login',

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -26,6 +26,23 @@ export default {
       let now = moment.utc().format('YYYY-MM-DD HH:mm');
       return `${this.$store.state.urls.observationPortalApiUrl}/semesters/?start_lte=${now}`;
     }
-  }
+  },
+  created: function () {
+    // if the route contains a public parameter, honor that
+    if (this.$route.query.public == undefined) {
+      let newQueryParams = {...this.$route.query};
+      if (this.$store.state.userIsAuthenticated) {
+        newQueryParams.public = "false";
+      }
+      else {
+        // anonymous users should see public data and science data by default
+        newQueryParams.public = "true";
+      }
+      this.$router.replace({
+        path: this.$route.path,
+        query: newQueryParams
+      });
+    }
+  },
 };
 </script>


### PR DESCRIPTION
There will also be a PR in the LCO specific repo to fully fix the data inspector stuff there.

This PR ensures the profile is fully retrieved before we try to load the data table, which is more inline with previous behavior and necessary to determine the routing we want to change based on users login status.